### PR TITLE
[Feature/DEV-14] 언론사 탭 Auto Carousel & Progress Bar animation

### DIFF
--- a/src/features/renderNews/components/list/tab/tab.css
+++ b/src/features/renderNews/components/list/tab/tab.css
@@ -34,7 +34,7 @@
   height: 100%;
   width: 0%;
   background-color: var(--surface-brand-default);
-  animation: progress-bar 5s linear forwards;
+  animation: progress-bar linear forwards;
 }
 
 @keyframes progress-bar {

--- a/src/features/renderNews/components/list/tab/tab.css
+++ b/src/features/renderNews/components/list/tab/tab.css
@@ -11,6 +11,10 @@
   color: var(--text-weak);
 }
 
+.list-tab-item p {
+  z-index: 1;
+}
+
 .selected-tab {
   background-color: var(--surface-brand-alt);
   color: var(--text-white-default);
@@ -18,5 +22,26 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
+
   gap: 20px;
+  position: relative;
+}
+
+.tab-progress {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  height: 100%;
+  width: 0%;
+  background-color: var(--surface-brand-default);
+  animation: progress-bar 5s linear forwards;
+}
+
+@keyframes progress-bar {
+  from {
+    width: 0%;
+  }
+  to {
+    width: 100%;
+  }
 }

--- a/src/features/renderNews/components/list/tab/tab.js
+++ b/src/features/renderNews/components/list/tab/tab.js
@@ -16,9 +16,7 @@ export function createTab({ currentCategoryIndex, currentCompanyIndex, currentDa
       const categoryElement = createTabItem({
         innerText: category,
         isSelected: categoryIndex === currentCategoryIndex,
-        children: `<p>${currentCompanyIndex + 1}/${
-          data[currentCategoryIndex].companies.length
-        }</p>`,
+        children: `${currentCompanyIndex + 1}/${data[currentCategoryIndex].companies.length}`,
       });
       categoryElement.addEventListener("click", () => updateCompanyType(categoryIndex));
       categories.appendChild(categoryElement);

--- a/src/features/renderNews/components/list/tab/tabItem.js
+++ b/src/features/renderNews/components/list/tab/tabItem.js
@@ -1,5 +1,7 @@
 import { updateNext } from "../../../utils/updateStates.js";
 
+const PROGRESS_DURATION_SEC = 20;
+
 const classes = {
   base: "list-tab-item",
   unselected: "available-medium14",
@@ -34,6 +36,7 @@ export function createTabItem({ innerText, children, isSelected }) {
 function startProgressBar(selectedButton) {
   const progressBar = document.createElement("div");
   progressBar.className = "tab-progress";
+  progressBar.style.animationDuration = `${PROGRESS_DURATION_SEC}s`;
   selectedButton.appendChild(progressBar);
 
   progressBar.addEventListener("animationend", updateNext, { once: true });

--- a/src/features/renderNews/components/list/tab/tabItem.js
+++ b/src/features/renderNews/components/list/tab/tabItem.js
@@ -24,7 +24,7 @@ export function createTabItem({ innerText, children, isSelected }) {
   button.innerHTML = `<p>${innerText}</p>`;
 
   if (isSelected) {
-    button.insertAdjacentHTML("beforeend", children);
+    button.insertAdjacentHTML("beforeend", `<p>${children}</p>`);
     startProgressBar(button);
   }
 

--- a/src/features/renderNews/components/list/tab/tabItem.js
+++ b/src/features/renderNews/components/list/tab/tabItem.js
@@ -1,3 +1,16 @@
+import { updateNext } from "../../../utils/updateStates.js";
+
+const classes = {
+  base: "list-tab-item",
+  unselected: "available-medium14",
+  selected: "selected-bold14 selected-tab",
+};
+
+const classMapping = {
+  true: `${classes.base} ${classes.selected}`,
+  false: `${classes.base} ${classes.unselected}`,
+};
+
 /**
  * @param {Object} props
  * @param {string} props.innerText
@@ -12,18 +25,16 @@ export function createTabItem({ innerText, children, isSelected }) {
 
   if (isSelected) {
     button.insertAdjacentHTML("beforeend", children);
+    startProgressBar(button);
   }
 
   return button;
 }
 
-const classes = {
-  base: "list-tab-item",
-  unselected: "available-medium14",
-  selected: "selected-bold14 selected-tab",
-};
+function startProgressBar(selectedButton) {
+  const progressBar = document.createElement("div");
+  progressBar.className = "tab-progress";
+  selectedButton.appendChild(progressBar);
 
-const classMapping = {
-  true: `${classes.base} ${classes.selected}`,
-  false: `${classes.base} ${classes.unselected}`,
-};
+  progressBar.addEventListener("animationend", updateNext, { once: true });
+}


### PR DESCRIPTION
### preview
<img width="1038" alt="스크린샷 2024-07-09 오후 5 57 24" src="https://github.com/softeerbootcamp4th/fe-newsstand/assets/80194238/9f6031db-2049-4b86-88ec-905458b8828b">

<img width="1046" alt="스크린샷 2024-07-09 오후 5 57 35" src="https://github.com/softeerbootcamp4th/fe-newsstand/assets/80194238/efbab16e-0b42-45a2-b106-9f8b610aaf9b">

### 작업 사항
1. 전체 언론사 및 구독한 언론사 내 탭 컴포넌트에 auto carousel 기능 도입: 
_-_ 다음 언론사 선택 button 에서 사용되는 updateNext 을 progress bar 'animationend' callback 으로 전달
2. keyframe 활용해 progress bar animation 구현

```js
function startProgressBar(selectedButton) {
  const progressBar = document.createElement("div");
  progressBar.className = "tab-progress";
  selectedButton.appendChild(progressBar);

  progressBar.addEventListener("animationend", updateNext, { once: true });
}
```


```css
.tab-progress {
  position: absolute;
  bottom: 0;
  left: 0;
  height: 100%;
  width: 0%;
  background-color: var(--surface-brand-default);
  animation: progress-bar linear forwards;
}

@keyframes progress-bar {
  from {
    width: 0%;
  }
  to {
    width: 100%;
  }
}
```