### PR TITLE
[Feature/DEV-18] 그리드 보기 화면 구현

### DIFF
--- a/src/apis/news.js
+++ b/src/apis/news.js
@@ -12,13 +12,13 @@ export const getCategoryList = async () => http.get("/categories");
 export const getHeadlineList = async () => http.get("/headlines");
 
 /**
- *
- * @param {number} categoryId
+ * @param {Object} props
+ * @param {number} props.categoryId
  * @returns {Promise<Company[]>}
  */
-export const getCompanyList = ({ categoryId }) => {
+export const getCompanyList = ({ categoryId = null } = {}) => {
   const params = new URLSearchParams();
   categoryId && params.set("categoryId", categoryId);
-
+  console.log(params);
   return http.get(`/companies?${params.toString()}`);
 };

--- a/src/apis/news.js
+++ b/src/apis/news.js
@@ -19,6 +19,5 @@ export const getHeadlineList = async () => http.get("/headlines");
 export const getCompanyList = ({ categoryId = null } = {}) => {
   const params = new URLSearchParams();
   categoryId && params.set("categoryId", categoryId);
-  console.log(params);
   return http.get(`/companies?${params.toString()}`);
 };

--- a/src/components/switcher/switcher.js
+++ b/src/components/switcher/switcher.js
@@ -51,10 +51,6 @@ function createInput({ item, name, itemIndex, onClick }) {
   input.type = "radio";
   input.addEventListener("change", onClick);
 
-  if (itemIndex === 0) {
-    input.checked = true;
-  }
-
   return input;
 }
 

--- a/src/features/renderNews/components/@common/companyLogo.js
+++ b/src/features/renderNews/components/@common/companyLogo.js
@@ -1,0 +1,8 @@
+import { Company } from "../../../../types/news.js";
+
+/**
+ * @param {Company} company
+ * @returns {string}
+ */
+export const createCompanyLogoTemplate = ({ logoUrl, name }) =>
+  `<img src=${logoUrl} alt='${name} 로고'/>`;

--- a/src/features/renderNews/components/grid/company/company.css
+++ b/src/features/renderNews/components/grid/company/company.css
@@ -1,5 +1,9 @@
-.grid-company {
+.grid-item {
   display: flex;
   justify-content: center;
   align-items: center;
+}
+
+.grid-item-company:hover {
+  background-color: var(--surface-alt);
 }

--- a/src/features/renderNews/components/grid/company/company.css
+++ b/src/features/renderNews/components/grid/company/company.css
@@ -1,0 +1,5 @@
+.grid-company {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}

--- a/src/features/renderNews/components/grid/company/company.css
+++ b/src/features/renderNews/components/grid/company/company.css
@@ -7,3 +7,7 @@
 .grid-item-company:hover {
   background-color: var(--surface-alt);
 }
+
+.hover-hidden {
+  display: none;
+}

--- a/src/features/renderNews/components/grid/company/company.css
+++ b/src/features/renderNews/components/grid/company/company.css
@@ -4,6 +4,10 @@
   align-items: center;
 }
 
+.grid-item-company {
+  cursor: pointer;
+}
+
 .grid-item-company:hover {
   background-color: var(--surface-alt);
 }

--- a/src/features/renderNews/components/grid/company/company.js
+++ b/src/features/renderNews/components/grid/company/company.js
@@ -6,7 +6,6 @@ import { createCompanyLogoTemplate } from "../../@common/companyLogo.js";
  * @param {Object} props
  * @param {HTMLDivElement} props.container
  * @param {Company} props.company
- * @param {} props.dataType
  * @returns {HTMLDivElement}
  */
 export function renderCompany({ container, company, dataType }) {
@@ -21,7 +20,9 @@ export function renderCompany({ container, company, dataType }) {
     company,
     isSubscribed,
     dataType,
+    isGridView: true,
   });
+
   subscriptionButton.classList.add("hover-hidden");
 
   container.addEventListener("mouseenter", () => {

--- a/src/features/renderNews/components/grid/company/company.js
+++ b/src/features/renderNews/components/grid/company/company.js
@@ -1,0 +1,15 @@
+import { createCompanyLogoTemplate } from "../../@common/companyLogo.js";
+
+/**
+ * @param {Company} company
+ * @returns {HTMLDivElement}
+ */
+export function createCompany(company) {
+  const companyElement = document.createElement("div");
+  companyElement.className = "grid-company";
+
+  const logo = createCompanyLogoTemplate(company);
+  companyElement.innerHTML = logo;
+
+  return companyElement;
+}

--- a/src/features/renderNews/components/grid/company/company.js
+++ b/src/features/renderNews/components/grid/company/company.js
@@ -1,15 +1,35 @@
+import { createSubscriptionButton } from "../../../../subscriptionButton/components/subscriptionButton.js";
+import { getObjectSubscribedCompanies } from "../../../../subscriptionButton/utils/localStorage.js";
 import { createCompanyLogoTemplate } from "../../@common/companyLogo.js";
 
 /**
- * @param {Company} company
+ * @param {Object} props
+ * @param {HTMLDivElement} props.container
+ * @param {Company} props.company
+ * @param {} props.dataType
  * @returns {HTMLDivElement}
  */
-export function createCompany(company) {
-  const companyElement = document.createElement("div");
-  companyElement.className = "grid-company";
+export function renderCompany({ container, company, dataType }) {
+  container.classList.add("grid-item-company");
 
   const logo = createCompanyLogoTemplate(company);
-  companyElement.innerHTML = logo;
+  container.innerHTML = logo;
 
-  return companyElement;
+  const subscriptions = getObjectSubscribedCompanies();
+  const isSubscribed = Object.hasOwn(subscriptions, company.id);
+  const subscriptionButton = createSubscriptionButton({
+    company,
+    isSubscribed,
+    dataType,
+  });
+
+  container.addEventListener("mouseenter", () => {
+    container.dataset.originalContent = container.innerHTML;
+    container.innerHTML = "";
+    container.appendChild(subscriptionButton);
+  });
+
+  container.addEventListener("mouseleave", () => {
+    container.innerHTML = container.dataset.originalContent;
+  });
 }

--- a/src/features/renderNews/components/grid/company/company.js
+++ b/src/features/renderNews/components/grid/company/company.js
@@ -12,8 +12,8 @@ import { createCompanyLogoTemplate } from "../../@common/companyLogo.js";
 export function renderCompany({ container, company, dataType }) {
   container.classList.add("grid-item-company");
 
-  const logo = createCompanyLogoTemplate(company);
-  container.innerHTML = logo;
+  const companyLogo = document.createElement("div");
+  companyLogo.innerHTML = createCompanyLogoTemplate(company);
 
   const subscriptions = getObjectSubscribedCompanies();
   const isSubscribed = Object.hasOwn(subscriptions, company.id);
@@ -22,14 +22,17 @@ export function renderCompany({ container, company, dataType }) {
     isSubscribed,
     dataType,
   });
+  subscriptionButton.classList.add("hover-hidden");
 
   container.addEventListener("mouseenter", () => {
-    container.dataset.originalContent = container.innerHTML;
-    container.innerHTML = "";
-    container.appendChild(subscriptionButton);
+    companyLogo.classList.add("hover-hidden");
+    subscriptionButton.classList.remove("hover-hidden");
   });
 
   container.addEventListener("mouseleave", () => {
-    container.innerHTML = container.dataset.originalContent;
+    companyLogo.classList.remove("hover-hidden");
+    subscriptionButton.classList.add("hover-hidden");
   });
+
+  container.append(companyLogo, subscriptionButton);
 }

--- a/src/features/renderNews/components/grid/company/company.js
+++ b/src/features/renderNews/components/grid/company/company.js
@@ -21,6 +21,7 @@ export function renderCompany({ container, company, dataType }) {
     isSubscribed,
     dataType,
     isGridView: true,
+    container,
   });
 
   subscriptionButton.classList.add("hover-hidden");

--- a/src/features/renderNews/components/grid/company/company.js
+++ b/src/features/renderNews/components/grid/company/company.js
@@ -6,9 +6,10 @@ import { createCompanyLogoTemplate } from "../../@common/companyLogo.js";
  * @param {Object} props
  * @param {HTMLDivElement} props.container
  * @param {Company} props.company
+ * @param {"all-news-tab" | "subscribed-news-tab"} props.dataTabId
  * @returns {HTMLDivElement}
  */
-export function renderCompany({ container, company, dataType }) {
+export function renderCompany({ container, company, dataTabId }) {
   container.classList.add("grid-item-company");
 
   const companyLogo = document.createElement("div");
@@ -19,7 +20,7 @@ export function renderCompany({ container, company, dataType }) {
   const subscriptionButton = createSubscriptionButton({
     company,
     isSubscribed,
-    dataType,
+    dataTabId,
     isGridView: true,
     container,
   });

--- a/src/features/renderNews/components/grid/index.js
+++ b/src/features/renderNews/components/grid/index.js
@@ -1,13 +1,12 @@
+import { MainNewsState } from "../../../../types/news.js";
 import { GRID_ITEM_PER_PAGE } from "../../constants/gridItemPerPage.js";
 import { renderCompany } from "./company/company.js";
 
 /**
  * @param {HTMLElement} viewContainer
- * @param {"all-news-tab" | "subscribed-news-tab"} state
+ * @param {MainNewsState} state
  */
-export function renderGridView(viewContainer, state) {
-  const { companies, currentDataIndex } = state;
-
+export function renderGridView(viewContainer, { companies, currentDataIndex, currentDataType }) {
   viewContainer.classList.add("grid-company-container");
 
   const currentCompanies = companies.slice(currentDataIndex, currentDataIndex + GRID_ITEM_PER_PAGE);
@@ -17,8 +16,7 @@ export function renderGridView(viewContainer, state) {
 
     let companyContainer = createCompanyContainer();
 
-    company &&
-      renderCompany({ container: companyContainer, company, dataType: state.currentDataType });
+    company && renderCompany({ container: companyContainer, company, dataType: currentDataType });
 
     viewContainer.appendChild(companyContainer);
   }

--- a/src/features/renderNews/components/grid/index.js
+++ b/src/features/renderNews/components/grid/index.js
@@ -6,17 +6,17 @@ import { renderCompany } from "./company/company.js";
  * @param {HTMLElement} viewContainer
  * @param {MainNewsState} state
  */
-export function renderGridView(viewContainer, { companies, currentDataIndex, currentDataType }) {
+export function renderGridView(viewContainer, { companies, companyIndex, dataTabId }) {
   viewContainer.classList.add("grid-company-container");
 
-  const currentCompanies = companies.slice(currentDataIndex, currentDataIndex + GRID_ITEM_PER_PAGE);
+  const currentCompanies = companies.slice(companyIndex, companyIndex + GRID_ITEM_PER_PAGE);
 
   for (let i = 0; i < GRID_ITEM_PER_PAGE; i++) {
     const company = currentCompanies[i];
 
     let companyContainer = createCompanyContainer();
 
-    company && renderCompany({ container: companyContainer, company, dataType: currentDataType });
+    company && renderCompany({ container: companyContainer, company, dataTabId });
 
     viewContainer.appendChild(companyContainer);
   }

--- a/src/features/renderNews/components/grid/index.js
+++ b/src/features/renderNews/components/grid/index.js
@@ -1,19 +1,31 @@
-import { MainNewsState } from "../../../../types/news.js";
-import { createCompany } from "./company/company.js";
+import { GRID_ITEM_PER_PAGE } from "../../constants/gridItemPerPage.js";
+import { renderCompany } from "./company/company.js";
 
 /**
- * @param {HTMLElement} container
- * @param {MainNewsState} state
+ * @param {HTMLElement} viewContainer
+ * @param {"all-news-tab" | "subscribed-news-tab"} state
  */
-export function renderGridView(container, state) {
+export function renderGridView(viewContainer, state) {
   const { companies, currentDataIndex } = state;
 
-  container.classList.add("grid-company-container");
+  viewContainer.classList.add("grid-company-container");
 
-  const currentPage = companies.slice(currentDataIndex, currentDataIndex + 24);
+  const currentCompanies = companies.slice(currentDataIndex, currentDataIndex + GRID_ITEM_PER_PAGE);
 
-  currentPage.forEach((company) => {
-    const companyElement = createCompany(company);
-    container.appendChild(companyElement);
-  });
+  for (let i = 0; i < GRID_ITEM_PER_PAGE; i++) {
+    const company = currentCompanies[i];
+
+    let companyContainer = createCompanyContainer();
+
+    company &&
+      renderCompany({ container: companyContainer, company, dataType: state.currentDataType });
+
+    viewContainer.appendChild(companyContainer);
+  }
+}
+
+function createCompanyContainer() {
+  let container = document.createElement("div");
+  container.className = "grid-item border-box";
+  return container;
 }

--- a/src/features/renderNews/components/grid/index.js
+++ b/src/features/renderNews/components/grid/index.js
@@ -1,4 +1,5 @@
 import { MainNewsState } from "../../../../types/news.js";
+import { createCompany } from "./company/company.js";
 
 /**
  * @param {HTMLElement} container
@@ -9,9 +10,10 @@ export function renderGridView(container, state) {
 
   container.classList.add("grid-company-container");
 
-  companies.slice(currentDataIndex, currentDataIndex + 24).forEach((company) => {
-    const companyElement = document.createElement("div");
-    companyElement.innerText = company.name;
+  const currentPage = companies.slice(currentDataIndex, currentDataIndex + 24);
+
+  currentPage.forEach((company) => {
+    const companyElement = createCompany(company);
     container.appendChild(companyElement);
   });
 }

--- a/src/features/renderNews/components/grid/index.js
+++ b/src/features/renderNews/components/grid/index.js
@@ -5,6 +5,13 @@ import { MainNewsState } from "../../../../types/news.js";
  * @param {MainNewsState} state
  */
 export function renderGridView(container, state) {
-  container;
-  state;
+  const { companies, currentDataIndex } = state;
+
+  container.classList.add("grid-company-container");
+
+  companies.slice(currentDataIndex, currentDataIndex + 24).forEach((company) => {
+    const companyElement = document.createElement("div");
+    companyElement.innerText = company.name;
+    container.appendChild(companyElement);
+  });
 }

--- a/src/features/renderNews/components/list/company/company.css
+++ b/src/features/renderNews/components/list/company/company.css
@@ -20,7 +20,7 @@
 
 /* contents */
 .company-container-contents {
-  overflow: hidden;
+  overflow: scroll;
   display: flex;
   gap: 32px;
 }
@@ -32,10 +32,12 @@
   gap: 16px;
 
   width: 320px;
+  min-width: 320px;
   overflow: hidden;
 }
 
 .main-news > img {
+  width: 320px;
   height: 200px;
   object-fit: cover;
 }

--- a/src/features/renderNews/components/list/company/company.css
+++ b/src/features/renderNews/components/list/company/company.css
@@ -1,16 +1,3 @@
-/* container */
-.list-company-container {
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
-
-  padding: 24px 0;
-}
-
-.list-company-container > div {
-  padding: 0 24px;
-}
-
 /* header */
 .company-container-header {
   display: flex;

--- a/src/features/renderNews/components/list/company/company.js
+++ b/src/features/renderNews/components/list/company/company.js
@@ -2,6 +2,7 @@ import { Company, NewsItem } from "../../../../../types/news.js";
 import { convertStringToFragment } from "../../../../../utils/convertStringToFragment.js";
 import { createSubscriptionButton } from "../../../../subscriptionButton/components/subscriptionButton.js";
 import { getObjectSubscribedCompanies } from "../../../../subscriptionButton/utils/localStorage.js";
+import { createCompanyLogoTemplate } from "../../@common/companyLogo.js";
 
 /**
  * @param {Company} company
@@ -26,16 +27,14 @@ export function createCompany(company, dataType) {
  * @returns {HTMLDivElement}
  */
 function createHeader(company, dataType) {
-  const { id, logoUrl, name, updatedDate } = company;
-  const formattedUpdatedDate = formatDateString(updatedDate);
+  const { id, updatedDate } = company;
 
   const header = document.createElement("div");
   header.className = "company-container-header display-medium12";
 
-  header.innerHTML = `
-                      <img src=${logoUrl} alt='${name} 로고'/>
-                      <time>${formattedUpdatedDate}</time>
-                    `;
+  const companyLogo = convertStringToFragment(createCompanyLogoTemplate(company));
+  const date = convertStringToFragment(`<time>${formatDateString(updatedDate)}</time>`);
+  header.append(companyLogo, date);
 
   const subscriptions = getObjectSubscribedCompanies();
   const isSubscribed = Object.hasOwn(subscriptions, id);

--- a/src/features/renderNews/components/list/company/company.js
+++ b/src/features/renderNews/components/list/company/company.js
@@ -38,7 +38,7 @@ function createHeader(company, dataType) {
 
   const subscriptions = getObjectSubscribedCompanies();
   const isSubscribed = Object.hasOwn(subscriptions, id);
-  const subscriptionButton = createSubscriptionButton({ company, isSubscribed, dataType });
+  const subscriptionButton = createSubscriptionButton({ company, dataType, isSubscribed });
   header.appendChild(subscriptionButton);
 
   return header;

--- a/src/features/renderNews/components/list/company/company.js
+++ b/src/features/renderNews/components/list/company/company.js
@@ -38,7 +38,11 @@ function createHeader(company, dataType) {
 
   const subscriptions = getObjectSubscribedCompanies();
   const isSubscribed = Object.hasOwn(subscriptions, id);
-  const subscriptionButton = createSubscriptionButton({ company, dataType, isSubscribed });
+  const subscriptionButton = createSubscriptionButton({
+    company,
+    dataTabId: dataType,
+    isSubscribed,
+  });
   header.appendChild(subscriptionButton);
 
   return header;

--- a/src/features/renderNews/components/list/index.js
+++ b/src/features/renderNews/components/list/index.js
@@ -9,7 +9,7 @@ import { convertStringToFragment } from "../../../../utils/convertStringToFragme
  * @param {MainNewsState} state
  */
 export async function renderListView(container, state) {
-  const currentCompany = state.data[state.currentCompanyIndex];
+  const currentCompany = state.companies[state.currentCompanyIndex];
 
   if (currentCompany) {
     const tab = await createTab(state);

--- a/src/features/renderNews/components/list/index.js
+++ b/src/features/renderNews/components/list/index.js
@@ -9,7 +9,7 @@ import { convertStringToFragment } from "../../../../utils/convertStringToFragme
  * @param {MainNewsState} state
  */
 export async function renderListView(container, state) {
-  const currentCompany = state.companies[state.currentCompanyIndex];
+  const currentCompany = state.companies[state.currentDataIndex];
 
   if (currentCompany) {
     const tab = await createTab(state);

--- a/src/features/renderNews/components/list/index.js
+++ b/src/features/renderNews/components/list/index.js
@@ -9,11 +9,11 @@ import { convertStringToFragment } from "../../../../utils/convertStringToFragme
  * @param {MainNewsState} state
  */
 export async function renderListView(container, state) {
-  const currentCompany = state.companies[state.currentDataIndex];
+  const currentCompany = state.companies[state.companyIndex];
 
   if (currentCompany) {
     const tab = await createTab(state);
-    const company = createCompany(currentCompany, state.currentDataType);
+    const company = createCompany(currentCompany, state.dataTabId);
     container.append(tab, company);
   } else {
     // Todo: 전체 언론사 페이지에서 선택한 카테고리 내 언론사 데이터 존재하지 않는 경우 에러 처리 필요

--- a/src/features/renderNews/components/list/tab/tab.js
+++ b/src/features/renderNews/components/list/tab/tab.js
@@ -4,7 +4,7 @@ import { MainNewsState } from "../../../../../types/news.js";
 import {
   setTotalTabNumber,
   updateCompany,
-  updateCompanyType,
+  updateListViewCompanyType,
 } from "../../../utils/updateStates.js";
 import { createTabItem } from "./tabItem.js";
 
@@ -24,7 +24,7 @@ export async function createTab({ currentTabId, currentCompanyIndex, currentData
         innerText: name,
         isSelected: +id === +currentTabId,
         children: `${currentCompanyIndex + 1}/${companies.length}`,
-        onClick: async () => await updateCompanyType(id),
+        onClick: async () => await updateListViewCompanyType(id),
       });
 
       container.appendChild(categoryElement);

--- a/src/features/renderNews/components/list/tab/tab.js
+++ b/src/features/renderNews/components/list/tab/tab.js
@@ -11,7 +11,12 @@ import { createTabItem } from "./tabItem.js";
 /**
  * @param {MainNewsState} state
  */
-export async function createTab({ currentTabId, currentCompanyIndex, currentDataType, companies }) {
+export async function createTab({
+  currentTabId,
+  currentDataIndex: currentCompanyIndex,
+  currentDataType,
+  companies,
+}) {
   const container = document.createElement("div");
   container.className = "list-tab border-box";
 

--- a/src/features/renderNews/components/list/tab/tab.js
+++ b/src/features/renderNews/components/list/tab/tab.js
@@ -11,24 +11,19 @@ import { createTabItem } from "./tabItem.js";
 /**
  * @param {MainNewsState} state
  */
-export async function createTab({
-  currentTabId,
-  currentDataIndex: currentCompanyIndex,
-  currentDataType,
-  companies,
-}) {
+export async function createTab({ categoryId, companyIndex, dataTabId, companies }) {
   const container = document.createElement("div");
   container.className = "list-tab border-box";
 
-  if (currentDataType === "all-news-tab") {
+  if (dataTabId === "all-news-tab") {
     const categoryList = await getCategoryList();
     setTotalTabNumberInListView(categoryList.length);
 
     categoryList.forEach(({ id, name }) => {
       const categoryElement = createTabItem({
         innerText: name,
-        isSelected: +id === +currentTabId,
-        children: `${currentCompanyIndex + 1}/${companies.length}`,
+        isSelected: +id === +categoryId,
+        children: `${companyIndex + 1}/${companies.length}`,
         onClick: async () => await selectCompanyTypeInListView(id),
       });
 
@@ -38,7 +33,7 @@ export async function createTab({
     companies.forEach(({ name: companyName }, companyIndex) => {
       const companyElement = createTabItem({
         innerText: companyName,
-        isSelected: companyIndex === currentCompanyIndex,
+        isSelected: companyIndex === companyIndex,
         children: createIcon({ iconId: "arrow" }),
         onClick: () => selectCompanyByIndexInListView(companyIndex),
       });

--- a/src/features/renderNews/components/list/tab/tab.js
+++ b/src/features/renderNews/components/list/tab/tab.js
@@ -2,9 +2,9 @@ import { createIcon } from "../../../../../components/icon/icon.js";
 import { getCategoryList } from "../../../../../apis/news.js";
 import { MainNewsState } from "../../../../../types/news.js";
 import {
-  setTotalTabNumber,
-  updateCompany,
-  updateListViewCompanyType,
+  setTotalTabNumberInListView,
+  selectCompanyInListViewSubscribedTab,
+  selectCompanyTypeInListView,
 } from "../../../utils/updateStates.js";
 import { createTabItem } from "./tabItem.js";
 
@@ -22,14 +22,14 @@ export async function createTab({
 
   if (currentDataType === "all-news-tab") {
     const categoryList = await getCategoryList();
-    setTotalTabNumber(categoryList.length);
+    setTotalTabNumberInListView(categoryList.length);
 
     categoryList.forEach(({ id, name }) => {
       const categoryElement = createTabItem({
         innerText: name,
         isSelected: +id === +currentTabId,
         children: `${currentCompanyIndex + 1}/${companies.length}`,
-        onClick: async () => await updateListViewCompanyType(id),
+        onClick: async () => await selectCompanyTypeInListView(id),
       });
 
       container.appendChild(categoryElement);
@@ -40,7 +40,7 @@ export async function createTab({
         innerText: companyName,
         isSelected: companyIndex === currentCompanyIndex,
         children: createIcon({ iconId: "arrow" }),
-        onClick: () => updateCompany(companyIndex),
+        onClick: () => selectCompanyInListViewSubscribedTab(companyIndex),
       });
 
       container.appendChild(companyElement);

--- a/src/features/renderNews/components/list/tab/tab.js
+++ b/src/features/renderNews/components/list/tab/tab.js
@@ -3,7 +3,7 @@ import { getCategoryList } from "../../../../../apis/news.js";
 import { MainNewsState } from "../../../../../types/news.js";
 import {
   setTotalTabNumberInListView,
-  selectCompanyInListViewSubscribedTab,
+  selectCompanyByIndexInListView,
   selectCompanyTypeInListView,
 } from "../../../utils/updateStates.js";
 import { createTabItem } from "./tabItem.js";
@@ -40,7 +40,7 @@ export async function createTab({
         innerText: companyName,
         isSelected: companyIndex === currentCompanyIndex,
         children: createIcon({ iconId: "arrow" }),
-        onClick: () => selectCompanyInListViewSubscribedTab(companyIndex),
+        onClick: () => selectCompanyByIndexInListView(companyIndex),
       });
 
       container.appendChild(companyElement);

--- a/src/features/renderNews/components/list/tab/tab.js
+++ b/src/features/renderNews/components/list/tab/tab.js
@@ -11,7 +11,7 @@ import { createTabItem } from "./tabItem.js";
 /**
  * @param {MainNewsState} state
  */
-export async function createTab({ currentTabId, currentCompanyIndex, currentDataType, data }) {
+export async function createTab({ currentTabId, currentCompanyIndex, currentDataType, companies }) {
   const container = document.createElement("div");
   container.className = "list-tab border-box";
 
@@ -23,14 +23,14 @@ export async function createTab({ currentTabId, currentCompanyIndex, currentData
       const categoryElement = createTabItem({
         innerText: name,
         isSelected: +id === +currentTabId,
-        children: `${currentCompanyIndex + 1}/${data.length}`,
+        children: `${currentCompanyIndex + 1}/${companies.length}`,
         onClick: async () => await updateCompanyType(id),
       });
 
       container.appendChild(categoryElement);
     });
   } else {
-    data.forEach(({ name: companyName }, companyIndex) => {
+    companies.forEach(({ name: companyName }, companyIndex) => {
       const companyElement = createTabItem({
         innerText: companyName,
         isSelected: companyIndex === currentCompanyIndex,

--- a/src/features/renderNews/constants/gridItemPerPage.js
+++ b/src/features/renderNews/constants/gridItemPerPage.js
@@ -1,0 +1,1 @@
+export const GRID_ITEM_PER_PAGE = 24;

--- a/src/features/renderNews/styles/layout.css
+++ b/src/features/renderNews/styles/layout.css
@@ -1,0 +1,19 @@
+/* container */
+.list-company-container {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+
+  padding: 24px 0;
+}
+
+.list-company-container > div {
+  padding: 0 24px;
+}
+
+.grid-company-container {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  grid-auto-rows: minmax(90px, auto);
+  justify-content: center;
+}

--- a/src/features/renderNews/utils/renderView.js
+++ b/src/features/renderNews/utils/renderView.js
@@ -14,5 +14,5 @@ export function render(state) {
   const container = document.getElementById("news-container");
   container.className = "border-box";
   container.innerHTML = "";
-  renderView[state.currentView](container, state);
+  renderView[state.viewTabId](container, state);
 }

--- a/src/features/renderNews/utils/updateStates.js
+++ b/src/features/renderNews/utils/updateStates.js
@@ -12,10 +12,9 @@ const state = {
   currentTabId: 1,
   totalTabNumber: 0,
   currentCompanyIndex: 0,
-  data: [],
+  companies: [],
 };
 
-/** todo: tab id data에서 가져와서 보완해야 함  */
 function resetIndexes() {
   state.currentTabId = 1;
   state.currentCompanyIndex = 0;
@@ -31,9 +30,9 @@ async function switchCompanyTab(tabId) {
 
   state.currentDataType = tabId;
   if (tabId === "all-news-tab") {
-    state.data = await getCompanyList({ categoryId: state.currentTabId });
+    state.companies = await getCompanyList({ categoryId: state.currentTabId });
   } else {
-    state.data = getArraySubscribedCompanies();
+    state.companies = getArraySubscribedCompanies();
   }
   resetIndexes();
   render(state);
@@ -42,6 +41,7 @@ async function switchCompanyTab(tabId) {
 /** 리스트 뷰 / 그리드 뷰 탭 선택 시 */
 function switchCompanyView(view) {
   state.currentView = view;
+
   resetIndexes();
   render(state);
 }
@@ -73,7 +73,7 @@ const updateCompanyState = {
 };
 
 async function updateData(categoryId) {
-  state.data = await getCompanyList({ categoryId });
+  state.companies = await getCompanyList({ categoryId });
   state.currentCompanyIndex = 0;
   state.currentTabId = categoryId;
 }
@@ -87,12 +87,12 @@ function updateNext() {
 }
 
 function updateListViewCompanyInSubscribedTab(offset) {
-  state.data = getArraySubscribedCompanies();
+  state.companies = getArraySubscribedCompanies();
 
   state.currentCompanyIndex += offset;
   if (state.currentCompanyIndex < 0) {
-    state.currentCompanyIndex = state.data.length - 1;
-  } else if (state.currentCompanyIndex >= state.data.length) {
+    state.currentCompanyIndex = state.companies.length - 1;
+  } else if (state.currentCompanyIndex >= state.companies.length) {
     state.currentCompanyIndex = 0;
   }
   render(state);
@@ -103,8 +103,8 @@ async function updateListViewCompanyInAllTab(offset) {
 
   if (state.currentCompanyIndex < 0) {
     await updateData(((state.currentTabId - 2 + state.totalTabNumber) % state.totalTabNumber) + 1);
-    state.currentCompanyIndex = state.data.length - 1;
-  } else if (state.currentCompanyIndex >= state.data.length) {
+    state.currentCompanyIndex = state.companies.length - 1;
+  } else if (state.currentCompanyIndex >= state.companies.length) {
     await updateData((state.currentTabId % state.totalTabNumber) + 1);
   }
   render(state);

--- a/src/features/renderNews/utils/updateStates.js
+++ b/src/features/renderNews/utils/updateStates.js
@@ -11,13 +11,13 @@ const state = {
   currentDataType: "all-news-tab",
   currentTabId: 1,
   totalTabNumber: 0,
-  currentCompanyIndex: 0,
+  currentDataIndex: 0,
   companies: [],
 };
 
 function resetIndexes() {
   state.currentTabId = 1;
-  state.currentCompanyIndex = 0;
+  state.currentDataIndex = 0;
 }
 
 /**
@@ -38,7 +38,10 @@ async function switchCompanyTab(tabId) {
   render(state);
 }
 
-/** 리스트 뷰 / 그리드 뷰 탭 선택 시 */
+/**
+ * 리스트 뷰 / 그리드 뷰 탭 선택 시
+ * @param {'list-view' | 'grid-view'} view
+ */
 function switchCompanyView(view) {
   state.currentView = view;
 
@@ -46,16 +49,9 @@ function switchCompanyView(view) {
   render(state);
 }
 
-/** 리스트 뷰 내 언론사 type(종합/경제, IT 등) 탭 선택 시 */
-async function updateCompanyType(categoryId) {
-  await updateData(categoryId);
-  state.currentTabId = categoryId;
-  render(state);
-}
-
 /** 내가 구독한 언론사 페이지에서 company 선택 시 */
 function updateCompany(companyIndex) {
-  state.currentCompanyIndex = companyIndex;
+  state.currentDataIndex = companyIndex;
   render(state);
 }
 
@@ -74,7 +70,7 @@ const updateCompanyState = {
 
 async function updateData(categoryId) {
   state.companies = await getCompanyList({ categoryId });
-  state.currentCompanyIndex = 0;
+  state.currentDataIndex = 0;
   state.currentTabId = categoryId;
 }
 
@@ -86,25 +82,31 @@ function updateNext() {
   updateCompanyState[state.currentView][state.currentDataType].next();
 }
 
+async function updateListViewCompanyType(categoryId) {
+  await updateData(categoryId);
+  state.currentTabId = categoryId;
+  render(state);
+}
+
 function updateListViewCompanyInSubscribedTab(offset) {
   state.companies = getArraySubscribedCompanies();
 
-  state.currentCompanyIndex += offset;
-  if (state.currentCompanyIndex < 0) {
-    state.currentCompanyIndex = state.companies.length - 1;
-  } else if (state.currentCompanyIndex >= state.companies.length) {
-    state.currentCompanyIndex = 0;
+  state.currentDataIndex += offset;
+  if (state.currentDataIndex < 0) {
+    state.currentDataIndex = state.companies.length - 1;
+  } else if (state.currentDataIndex >= state.companies.length) {
+    state.currentDataIndex = 0;
   }
   render(state);
 }
 
 async function updateListViewCompanyInAllTab(offset) {
-  state.currentCompanyIndex += offset;
+  state.currentDataIndex += offset;
 
-  if (state.currentCompanyIndex < 0) {
+  if (state.currentDataIndex < 0) {
     await updateData(((state.currentTabId - 2 + state.totalTabNumber) % state.totalTabNumber) + 1);
-    state.currentCompanyIndex = state.companies.length - 1;
-  } else if (state.currentCompanyIndex >= state.companies.length) {
+    state.currentDataIndex = state.companies.length - 1;
+  } else if (state.currentDataIndex >= state.companies.length) {
     await updateData((state.currentTabId % state.totalTabNumber) + 1);
   }
   render(state);
@@ -126,7 +128,7 @@ export {
   switchCompanyView,
   updatePrev,
   updateNext,
-  updateCompanyType,
+  updateListViewCompanyType,
   switchCompanyTab,
   rerenderListViewCompanyInSubscribedTab,
   setTotalTabNumber,

--- a/src/features/renderNews/utils/updateStates.js
+++ b/src/features/renderNews/utils/updateStates.js
@@ -19,32 +19,32 @@ const state = {
 const updateState = {
   ["list-view"]: {
     ["all-news-tab"]: {
-      prev: () => updateListViewCompanyInAllTab(-1),
-      next: () => updateListViewCompanyInAllTab(1),
+      prev: () => selectCompanyInListViewAllTab(-1),
+      next: () => selectCompanyInListViewAllTab(1),
     },
     ["subscribed-news-tab"]: {
-      prev: () => updateListViewCompanyInSubscribedTab(1),
-      next: () => updateListViewCompanyInSubscribedTab(1),
-      rerender: () => updateListViewCompanyInSubscribedTab(0),
+      prev: () => selectCompanyInListViewSubscribedTab(-1),
+      next: () => selectCompanyInListViewSubscribedTab(1),
+      rerender: () => selectCompanyInListViewSubscribedTab(0),
     },
   },
   ["grid-view"]: {
     ["all-news-tab"]: {
-      prev: () => updateGridViewCompany(1),
-      next: () => updateGridViewCompany(1),
+      prev: () => selectGridViewPage(-1),
+      next: () => selectGridViewPage(1),
       rerender: () => render(state),
     },
     ["subscribed-news-tab"]: {
-      prev: () => updateGridViewCompany(1),
-      next: () => updateGridViewCompany(1),
-      rerender: () => updateGridViewCompany(0),
+      prev: () => selectGridViewPage(-1),
+      next: () => selectGridViewPage(1),
+      rerender: () => selectGridViewPage(0),
     },
   },
 };
 
 async function renderInit() {
-  setTabState("grid-view", "currentView");
-  setTabState("all-news-tab", "currentDataType");
+  selectTab("grid-view", "currentView");
+  selectTab("all-news-tab", "currentDataType");
 
   state.companies = await getCompanyList({ categoryId: state.currentTabId });
 
@@ -55,9 +55,9 @@ async function renderInit() {
  * 전체 언론사 보기 / 내가 구독한 언론사 보기 탭 선택 시
  * @param {MainNewsState.currentDataType} tabId
  */
-async function switchCompanyTab(tabId) {
+async function switchCompanyData(tabId) {
   resetIndexes();
-  setTabState(tabId, "currentDataType");
+  selectTab(tabId, "currentDataType");
 
   state.companies =
     tabId === "all-news-tab"
@@ -73,7 +73,7 @@ async function switchCompanyTab(tabId) {
  */
 async function switchCompanyView(view) {
   state.currentView = view;
-  await switchCompanyTab(state.currentDataType);
+  await switchCompanyData(state.currentDataType);
 }
 
 function updatePrev() {
@@ -86,19 +86,18 @@ function updateNext() {
 
 /** list view */
 
-/** 리스트 뷰 내 내가 구독한 언론사 페이지에서 company 선택 시 */
-function updateCompany(companyIndex) {
+function selectCompanyInListViewSubscribedTab(companyIndex) {
   state.currentDataIndex = companyIndex;
   render(state);
 }
 
-async function updateListViewCompanyType(categoryId) {
+async function selectCompanyTypeInListView(categoryId) {
   await updateData(categoryId);
   state.currentTabId = categoryId;
   render(state);
 }
 
-function updateListViewCompanyInSubscribedTab(offset) {
+function selectCompanyInListViewSubscribedTab(offset) {
   state.currentDataIndex += offset;
 
   if (state.currentDataIndex < 0) {
@@ -110,7 +109,7 @@ function updateListViewCompanyInSubscribedTab(offset) {
   render(state);
 }
 
-async function updateListViewCompanyInAllTab(offset) {
+async function selectCompanyInListViewAllTab(offset) {
   state.currentDataIndex += offset;
 
   if (state.currentDataIndex < 0) {
@@ -131,13 +130,13 @@ function rerenderInSubscribedTab() {
 /**
  * @param {number} total
  */
-function setTotalTabNumber(total) {
+function setTotalTabNumberInListView(total) {
   state.totalTabNumber = total;
 }
 
 /* grid view */
 
-function updateGridViewCompany(offset) {
+function selectGridViewPage(offset) {
   const newIndex = state.currentDataIndex + offset * GRID_ITEM_PER_PAGE;
 
   if (newIndex < 0) {
@@ -163,7 +162,7 @@ function resetIndexes() {
   state.currentDataIndex = 0;
 }
 
-function setTabState(elementId, stateKey) {
+function selectTab(elementId, stateKey) {
   const element = document.getElementById(elementId);
   if (element) {
     element.checked = true;
@@ -179,13 +178,13 @@ async function updateData(categoryId) {
 
 export {
   renderInit,
-  updateCompany,
-  switchCompanyView,
   updatePrev,
   updateNext,
-  updateListViewCompanyType,
-  switchCompanyTab,
-  rerenderInGridView as rerenderCompanyInGridView,
-  rerenderInSubscribedTab as rerenderCompanyInSubscribedTab,
-  setTotalTabNumber,
+  switchCompanyData,
+  switchCompanyView,
+  selectCompanyInListViewSubscribedTab,
+  selectCompanyTypeInListView,
+  rerenderInGridView,
+  rerenderInSubscribedTab,
+  setTotalTabNumberInListView,
 };

--- a/src/features/renderNews/utils/updateStates.js
+++ b/src/features/renderNews/utils/updateStates.js
@@ -55,7 +55,7 @@ function updateCompany(companyIndex) {
   render(state);
 }
 
-const updateCompanyState = {
+const updateState = {
   ["list-view"]: {
     ["all-news-tab"]: {
       prev: () => updateListViewCompanyInAllTab(-1),
@@ -75,11 +75,11 @@ async function updateData(categoryId) {
 }
 
 function updatePrev() {
-  updateCompanyState[state.currentView][state.currentDataType].prev();
+  updateState[state.currentView][state.currentDataType].prev();
 }
 
 function updateNext() {
-  updateCompanyState[state.currentView][state.currentDataType].next();
+  updateState[state.currentView][state.currentDataType].next();
 }
 
 async function updateListViewCompanyType(categoryId) {

--- a/src/features/renderNews/utils/updateStates.js
+++ b/src/features/renderNews/utils/updateStates.js
@@ -60,15 +60,21 @@ async function renderInit() {
 
 /**
  * 전체 언론사 보기 / 구독한 언론사 보기 탭 선택 시
- * @param {"all-news-tab" | "subscribed-news-tab"} tabId
+ * @param {"all-news-tab" | "subscribed-news-tab"} dataTabId
+ * @param {'list-view' | 'grid-view' | undefined} [view]
  */
-async function switchCompanyData(tabId) {
-  resetIndexes();
-  selectTab(tabId, "currentDataType");
+async function switchCompanyData(dataTabId, view) {
+  const viewTabId = view ?? (dataTabId === ALL_NEWS_TAB ? GRID_VIEW : LIST_VIEW);
+  const categoryId = viewTabId === LIST_VIEW ? 1 : null;
 
+  selectTab(dataTabId, "currentDataType");
+  selectTab(viewTabId, "currentView");
+
+  state.currentDataIndex = 0;
+  state.currentTabId = categoryId;
   state.companies =
-    tabId === ALL_NEWS_TAB
-      ? await getCompanyList({ categoryId: state.currentTabId })
+    dataTabId === ALL_NEWS_TAB
+      ? await getCompanyList({ categoryId })
       : getArraySubscribedCompanies();
 
   render(state);
@@ -79,8 +85,7 @@ async function switchCompanyData(tabId) {
  * @param {'list-view' | 'grid-view'} view
  */
 async function switchCompanyView(view) {
-  state.currentView = view;
-  await switchCompanyData(state.currentDataType);
+  await switchCompanyData(state.currentDataType, view);
 }
 
 /* 이전/다음 버튼 클릭 시 */
@@ -165,11 +170,6 @@ function rerenderInGridView() {
 }
 
 /** utils */
-
-function resetIndexes() {
-  state.currentTabId = state.currentView === LIST_VIEW ? 1 : null;
-  state.currentDataIndex = 0;
-}
 
 function selectTab(elementId, stateKey) {
   const element = document.getElementById(elementId);

--- a/src/features/renderNews/utils/updateStates.js
+++ b/src/features/renderNews/utils/updateStates.js
@@ -67,6 +67,7 @@ const updateState = {
     ["subscribed-news-tab"]: {
       prev: () => updateListViewCompanyInSubscribedTab(-1),
       next: () => updateListViewCompanyInSubscribedTab(1),
+      rerender: () => updateListViewCompanyInSubscribedTab(0),
     },
   },
   ["grid-view"]: {
@@ -77,6 +78,10 @@ const updateState = {
     ["subscribed-news-tab"]: {
       prev: () => updateGridViewCompany(-1),
       next: () => updateGridViewCompany(1),
+      rerender: () => {
+        state.companies = getArraySubscribedCompanies();
+        updateGridViewCompany(0);
+      },
     },
   },
 };
@@ -131,8 +136,8 @@ async function updateListViewCompanyInAllTab(offset) {
   render(state);
 }
 
-function rerenderListViewCompanyInSubscribedTab() {
-  updateListViewCompanyInSubscribedTab(0);
+function rerenderCompanyInSubscribedTab() {
+  updateState[state.currentView]["subscribed-news-tab"].rerender();
 }
 
 /** grid view */
@@ -163,6 +168,6 @@ export {
   updateNext,
   updateListViewCompanyType,
   switchCompanyTab,
-  rerenderListViewCompanyInSubscribedTab,
+  rerenderCompanyInSubscribedTab,
   setTotalTabNumber,
 };

--- a/src/features/renderNews/utils/updateStates.js
+++ b/src/features/renderNews/utils/updateStates.js
@@ -2,6 +2,7 @@ import { render } from "./renderView.js";
 import { MainNewsState } from "../../../types/news.js";
 import { getArraySubscribedCompanies } from "../../subscriptionButton/utils/localStorage.js";
 import { getCompanyList } from "../../../apis/news.js";
+import { GRID_ITEM_PER_PAGE } from "../constants/gridItemPerPage.js";
 
 /**
  * @type {MainNewsState}
@@ -136,9 +137,10 @@ function rerenderListViewCompanyInSubscribedTab() {
 
 /** grid view */
 function updateGridViewCompany(offset) {
-  state.currentDataIndex += offset * 24;
+  state.currentDataIndex += offset * GRID_ITEM_PER_PAGE;
   if (state.currentDataIndex < 0) {
-    state.currentDataIndex = Math.floor(state.companies.length / 24) * 24;
+    state.currentDataIndex =
+      Math.floor(state.companies.length / GRID_ITEM_PER_PAGe) * GRID_ITEM_PER_PAGE;
   } else if (state.currentDataIndex >= state.companies.length) {
     state.currentDataIndex = 0;
   }

--- a/src/features/subscriptionButton/components/subscribeToast.js
+++ b/src/features/subscriptionButton/components/subscribeToast.js
@@ -1,5 +1,8 @@
 import { showToast } from "../../../components/overlays/toast/toast.js";
-import { switchCompanyTab } from "../../renderNews/utils/updateStates.js";
+import {
+  rerenderCompanyInGridView,
+  switchCompanyTab,
+} from "../../renderNews/utils/updateStates.js";
 import { dispatchSubscriptionUpdateEvent } from "../utils/dispatchSubscriptionUpdateEvent.js";
 import { addSubscribedCompany } from "../utils/localStorage.js";
 
@@ -7,8 +10,9 @@ const TOAST_SHOWING_TIME = 5000;
 
 /**
  * @param {Company} company
+ * @param {boolean} [isGridView=false]
  */
-export function showSubscribeToast(company) {
+export function showSubscribeToast(company, isGridView) {
   showToast("내가 구독한 언론사에 추가되었습니다.", TOAST_SHOWING_TIME);
   addSubscribedCompany(company);
 
@@ -16,5 +20,7 @@ export function showSubscribeToast(company) {
     await switchCompanyTab("subscribed-news-tab");
   }, TOAST_SHOWING_TIME);
 
-  dispatchSubscriptionUpdateEvent({ company, isSubscribed: true });
+  isGridView
+    ? rerenderCompanyInGridView()
+    : dispatchSubscriptionUpdateEvent({ company, isSubscribed: true });
 }

--- a/src/features/subscriptionButton/components/subscribeToast.js
+++ b/src/features/subscriptionButton/components/subscribeToast.js
@@ -14,7 +14,7 @@ export function showSubscribeToast(company, isGridView) {
   addSubscribedCompany(company);
 
   setTimeout(async () => {
-    await switchCompanyData("subscribed-news-tab");
+    await switchCompanyData({ dataTapId: "subscribed-news-tab" });
   }, TOAST_SHOWING_TIME);
 
   isGridView

--- a/src/features/subscriptionButton/components/subscribeToast.js
+++ b/src/features/subscriptionButton/components/subscribeToast.js
@@ -1,8 +1,5 @@
 import { showToast } from "../../../components/overlays/toast/toast.js";
-import {
-  rerenderCompanyInGridView,
-  switchCompanyTab,
-} from "../../renderNews/utils/updateStates.js";
+import { rerenderInGridView, switchCompanyData } from "../../renderNews/utils/updateStates.js";
 import { dispatchSubscriptionUpdateEvent } from "../utils/dispatchSubscriptionUpdateEvent.js";
 import { addSubscribedCompany } from "../utils/localStorage.js";
 
@@ -17,10 +14,10 @@ export function showSubscribeToast(company, isGridView) {
   addSubscribedCompany(company);
 
   setTimeout(async () => {
-    await switchCompanyTab("subscribed-news-tab");
+    await switchCompanyData("subscribed-news-tab");
   }, TOAST_SHOWING_TIME);
 
   isGridView
-    ? rerenderCompanyInGridView()
+    ? rerenderInGridView()
     : dispatchSubscriptionUpdateEvent({ company, isSubscribed: true });
 }

--- a/src/features/subscriptionButton/components/subscriptionButton.js
+++ b/src/features/subscriptionButton/components/subscriptionButton.js
@@ -12,7 +12,7 @@ const buttonProps = {
  * @typedef {Object} SubscriptionButtonProps
  * @property {Company} company
  * @property {boolean} isSubscribed
- * @property {"all-news-tab" | "subscribed-news-tab"} [dataType="all-news-tab"]
+ * @property {"all-news-tab" | "subscribed-news-tab"} [dataTabId="all-news-tab"]
  * @property {boolean} [isGridView=false]
  */
 
@@ -41,9 +41,9 @@ export function createSubscriptionButton({ container, ...props }) {
  * @param {SubscriptionButtonProps} props
  */
 function handleSubscriptionClick(props) {
-  const { company, isSubscribed, isGridView, dataType } = props;
+  const { company, isSubscribed, isGridView, dataTabId } = props;
 
   isSubscribed
-    ? showUnsubscribeDialog({ company, isGridView, dataType })
+    ? showUnsubscribeDialog({ company, isGridView, dataTabId })
     : showSubscribeToast(company, isGridView);
 }

--- a/src/features/subscriptionButton/components/subscriptionButton.js
+++ b/src/features/subscriptionButton/components/subscriptionButton.js
@@ -1,4 +1,5 @@
 import { createButton } from "../../../components/button/button.js";
+import { Company } from "../../../types/news.js";
 import { showSubscribeToast } from "../components/subscribeToast.js";
 import { showUnsubscribeDialog } from "../components/unsubscribeDialog/unsubscribeDialog.js";
 
@@ -8,18 +9,39 @@ const buttonProps = {
 };
 
 /**
- * @param {Object} props
- * @param {Company} props.company
- * @param {boolean} props.isSubscribed
- * @param {"all-news-tab" | "subscribed-news-tab"} props.dataType
+ * @typedef {Object} SubscriptionButtonProps
+ * @property {Company} company
+ * @property {boolean} isSubscribed
+ * @property {"all-news-tab" | "subscribed-news-tab"} [dataType="all-news-tab"]
+ * @property {boolean} [isGridView=false]
+ */
+
+/**
+ * @param {SubscriptionButtonProps} props
  * @returns {HTMLButtonElement}
  */
-export function createSubscriptionButton({ company, isSubscribed, dataType }) {
+export function createSubscriptionButton(props) {
+  const {
+    company: { id, name },
+    isSubscribed,
+  } = props;
+
   const button = createButton(buttonProps[isSubscribed]);
-  button.setAttribute("data-company-id", company.id);
-  button.setAttribute("aria-label", `${company.name} ${buttonProps[isSubscribed].ariaLabel}`);
-  button.addEventListener("click", () =>
-    isSubscribed ? showUnsubscribeDialog(company, dataType) : showSubscribeToast(company)
-  );
+
+  button.setAttribute("data-company-id", id);
+  button.setAttribute("aria-label", `${name} ${buttonProps[isSubscribed].ariaLabel}`);
+  button.addEventListener("click", () => handleSubscriptionClick(props));
+
   return button;
+}
+
+/**
+ * @param {SubscriptionButtonProps} props
+ */
+function handleSubscriptionClick(props) {
+  const { company, isSubscribed, isGridView, dataType } = props;
+
+  isSubscribed
+    ? showUnsubscribeDialog({ company, isGridView, dataType })
+    : showSubscribeToast(company, isGridView);
 }

--- a/src/features/subscriptionButton/components/subscriptionButton.js
+++ b/src/features/subscriptionButton/components/subscriptionButton.js
@@ -18,19 +18,21 @@ const buttonProps = {
 
 /**
  * @param {SubscriptionButtonProps} props
+ * @param {HTMLDivElement} container
  * @returns {HTMLButtonElement}
  */
-export function createSubscriptionButton(props) {
+export function createSubscriptionButton({ container, ...props }) {
   const {
     company: { id, name },
     isSubscribed,
+    isGridView = false,
   } = props;
 
   const button = createButton(buttonProps[isSubscribed]);
 
   button.setAttribute("data-company-id", id);
   button.setAttribute("aria-label", `${name} ${buttonProps[isSubscribed].ariaLabel}`);
-  button.addEventListener("click", () => handleSubscriptionClick(props));
+  (isGridView ? container : button).addEventListener("click", () => handleSubscriptionClick(props));
 
   return button;
 }

--- a/src/features/subscriptionButton/components/unsubscribeDialog/unsubscribeDialog.js
+++ b/src/features/subscriptionButton/components/unsubscribeDialog/unsubscribeDialog.js
@@ -1,6 +1,6 @@
 import { showDialog } from "../../../../components/overlays/dialog/dialog.js";
 import { Company } from "../../../../types/news.js";
-import { rerenderListViewCompanyInSubscribedTab } from "../../../renderNews/utils/updateStates.js";
+import { rerenderCompanyInSubscribedTab } from "../../../renderNews/utils/updateStates.js";
 import { dispatchSubscriptionUpdateEvent } from "../../utils/dispatchSubscriptionUpdateEvent.js";
 import { removeSubscribedCompany } from "../../utils/localStorage.js";
 
@@ -14,7 +14,7 @@ export function showUnsubscribeDialog(company, dataType) {
     onClick: () => {
       removeSubscribedCompany(company.id);
       dispatchSubscriptionUpdateEvent({ company, isSubscribed: false });
-      dataType === "subscribed-news-tab" && rerenderListViewCompanyInSubscribedTab();
+      dataType === "subscribed-news-tab" && rerenderCompanyInSubscribedTab();
     },
   };
 

--- a/src/features/subscriptionButton/components/unsubscribeDialog/unsubscribeDialog.js
+++ b/src/features/subscriptionButton/components/unsubscribeDialog/unsubscribeDialog.js
@@ -1,8 +1,8 @@
 import { showDialog } from "../../../../components/overlays/dialog/dialog.js";
 import { Company } from "../../../../types/news.js";
 import {
-  rerenderCompanyInGridView,
-  rerenderCompanyInSubscribedTab,
+  rerenderInGridView,
+  rerenderInSubscribedTab,
 } from "../../../renderNews/utils/updateStates.js";
 import { dispatchSubscriptionUpdateEvent } from "../../utils/dispatchSubscriptionUpdateEvent.js";
 import { removeSubscribedCompany } from "../../utils/localStorage.js";
@@ -45,9 +45,9 @@ function handleUnsubscribe({ company, isGridView, dataType }) {
   removeSubscribedCompany(company.id);
 
   if (dataType === "subscribed-news-tab") {
-    rerenderCompanyInSubscribedTab();
+    rerenderInSubscribedTab();
   } else if (isGridView) {
-    rerenderCompanyInGridView();
+    rerenderInGridView();
   } else {
     dispatchSubscriptionUpdateEvent({ company, isSubscribed: false });
   }

--- a/src/features/subscriptionButton/components/unsubscribeDialog/unsubscribeDialog.js
+++ b/src/features/subscriptionButton/components/unsubscribeDialog/unsubscribeDialog.js
@@ -10,7 +10,7 @@ import { removeSubscribedCompany } from "../../utils/localStorage.js";
 /**
  * @param {Object} props
  * @param {Company} props.company
- * @param {"all-news-tab" | "subscribed-news-tab"} props.dataType
+ * @param {"all-news-tab" | "subscribed-news-tab"} props.dataTabId
  * @param {boolean} props.isGridView
  */
 export function showUnsubscribeDialog(props) {
@@ -39,12 +39,12 @@ export function showUnsubscribeDialog(props) {
  * @param {Object} props
  * @param {Company} props.company
  * @param {boolean} props.isGridView
- * @param {"all-news-tab" | "subscribed-news-tab"} props.dataType
+ * @param {"all-news-tab" | "subscribed-news-tab"} props.dataTabId
  */
-function handleUnsubscribe({ company, isGridView, dataType }) {
+function handleUnsubscribe({ company, isGridView, dataTabId }) {
   removeSubscribedCompany(company.id);
 
-  if (dataType === "subscribed-news-tab") {
+  if (dataTabId === "subscribed-news-tab") {
     rerenderInSubscribedTab();
   } else if (isGridView) {
     rerenderInGridView();

--- a/src/features/subscriptionButton/components/unsubscribeDialog/unsubscribeDialog.js
+++ b/src/features/subscriptionButton/components/unsubscribeDialog/unsubscribeDialog.js
@@ -1,21 +1,26 @@
 import { showDialog } from "../../../../components/overlays/dialog/dialog.js";
 import { Company } from "../../../../types/news.js";
-import { rerenderCompanyInSubscribedTab } from "../../../renderNews/utils/updateStates.js";
+import {
+  rerenderCompanyInGridView,
+  rerenderCompanyInSubscribedTab,
+} from "../../../renderNews/utils/updateStates.js";
 import { dispatchSubscriptionUpdateEvent } from "../../utils/dispatchSubscriptionUpdateEvent.js";
 import { removeSubscribedCompany } from "../../utils/localStorage.js";
 
 /**
- * @param {Company} company
- * @param {"all-news-tab" | "subscribed-news-tab"} dataType
+ * @param {Object} props
+ * @param {Company} props.company
+ * @param {"all-news-tab" | "subscribed-news-tab"} props.dataType
+ * @param {boolean} props.isGridView
  */
-export function showUnsubscribeDialog(company, dataType) {
+export function showUnsubscribeDialog(props) {
+  const {
+    company: { name },
+  } = props;
+
   const confirmProps = {
     text: "예, 해지합니다",
-    onClick: () => {
-      removeSubscribedCompany(company.id);
-      dispatchSubscriptionUpdateEvent({ company, isSubscribed: false });
-      dataType === "subscribed-news-tab" && rerenderCompanyInSubscribedTab();
-    },
+    onClick: () => handleUnsubscribe(props),
   };
 
   const cancelProps = {
@@ -24,8 +29,26 @@ export function showUnsubscribeDialog(company, dataType) {
   };
 
   showDialog({
-    message: `<strong>${company.name}</strong>을(를)<br/> 구독해지하시겠습니까?`,
+    message: `<strong>${name}</strong>을(를)<br/> 구독해지하시겠습니까?`,
     leftButtonProps: confirmProps,
     rightButtonProps: cancelProps,
   });
+}
+
+/**
+ * @param {Object} props
+ * @param {Company} props.company
+ * @param {boolean} props.isGridView
+ * @param {"all-news-tab" | "subscribed-news-tab"} props.dataType
+ */
+function handleUnsubscribe({ company, isGridView, dataType }) {
+  removeSubscribedCompany(company.id);
+
+  if (dataType === "subscribed-news-tab") {
+    rerenderCompanyInSubscribedTab();
+  } else if (isGridView) {
+    rerenderCompanyInGridView();
+  } else {
+    dispatchSubscriptionUpdateEvent({ company, isSubscribed: false });
+  }
 }

--- a/src/features/subscriptionButton/utils/dispatchSubscriptionUpdateEvent.js
+++ b/src/features/subscriptionButton/utils/dispatchSubscriptionUpdateEvent.js
@@ -17,8 +17,10 @@ export function dispatchSubscriptionUpdateEvent(detail) {
 
 document.addEventListener("DOMContentLoaded", () => {
   window.addEventListener(SUBSCRIPTION_EVENT_KEY, ({ detail }) => {
-    const { company } = detail;
-    const subscriptionButton = document.querySelector(`[data-company-id="${company.id}"]`);
+    const {
+      company: { id },
+    } = detail;
+    const subscriptionButton = document.querySelector(`[data-company-id="${id}"]`);
 
     if (subscriptionButton) {
       const newButton = createSubscriptionButton(detail);

--- a/src/main.js
+++ b/src/main.js
@@ -5,7 +5,7 @@ import { dataTabItems, viewTabItems } from "./features/renderNews/constants/tabI
 import { createMainArrowButton } from "./features/renderNews/components/@common/mainArrowButton/mainArrowButton.js";
 
 import {
-  switchCompanyTab,
+  switchCompanyData,
   switchCompanyView,
   updateNext,
   updatePrev,
@@ -59,7 +59,7 @@ function renderSwitcher() {
   const tabSwitcher = createSwitcher({
     className: "tab-switcher",
     items: dataTabItems,
-    onClick: async (event) => await switchCompanyTab(event.target.id),
+    onClick: async (event) => await switchCompanyData(event.target.id),
   });
 
   const viewSwitcher = createSwitcher({

--- a/src/main.js
+++ b/src/main.js
@@ -59,7 +59,7 @@ function renderSwitcher() {
   const tabSwitcher = createSwitcher({
     className: "tab-switcher",
     items: dataTabItems,
-    onClick: async (event) => await switchCompanyData(event.target.id),
+    onClick: async (event) => await switchCompanyData({ dataTabId: event.target.id }),
   });
 
   const viewSwitcher = createSwitcher({

--- a/src/main.js
+++ b/src/main.js
@@ -9,6 +9,7 @@ import {
   switchCompanyView,
   updateNext,
   updatePrev,
+  renderInit,
 } from "./features/renderNews/utils/updateStates.js";
 import { getHeadlineList } from "./apis/news.js";
 
@@ -64,7 +65,7 @@ function renderSwitcher() {
   const viewSwitcher = createSwitcher({
     className: "view-switcher",
     items: viewTabItems,
-    onClick: (event) => switchCompanyView(event.target.id),
+    onClick: async (event) => await switchCompanyView(event.target.id),
   });
 
   navContainer.append(tabSwitcher, viewSwitcher);
@@ -72,7 +73,7 @@ function renderSwitcher() {
 
 /** render news view */
 async function renderNewsView() {
-  await switchCompanyTab("all-news-tab");
+  await renderInit();
 
   const container = document.getElementById("main-news-contents");
 

--- a/src/style/layout.css
+++ b/src/style/layout.css
@@ -18,8 +18,8 @@ body {
 }
 
 #contents-container {
-  padding: 10px 20px;
-  max-width: calc(40px + 930px); /* add padding s*/
+  padding: 50px;
+  max-width: calc(100px + 930px); /* add paddings */
   width: 100%;
 }
 

--- a/src/style/loadStyles.js
+++ b/src/style/loadStyles.js
@@ -17,9 +17,10 @@ const stylesheets = [
 
   "src/features/renderNews/components/@common/mainArrowButton/mainArrowButton.css",
 
+  "src/features/renderNews/styles/layout.css",
   "src/features/renderNews/components/list/company/company.css",
   "src/features/renderNews/components/list/tab/tab.css",
-  "src/features/renderNews/styles/layout.css",
+  "src/features/renderNews/components/grid/company/company.css",
 ];
 
 stylesheets.forEach(loadCSS);

--- a/src/style/loadStyles.js
+++ b/src/style/loadStyles.js
@@ -19,6 +19,7 @@ const stylesheets = [
 
   "src/features/renderNews/components/list/company/company.css",
   "src/features/renderNews/components/list/tab/tab.css",
+  "src/features/renderNews/styles/layout.css",
 ];
 
 stylesheets.forEach(loadCSS);

--- a/src/types/news.js
+++ b/src/types/news.js
@@ -26,10 +26,10 @@
 
 /**
  * @typedef {Object} MainNewsState
- * @property {'list-view' | 'grid-view' } MainNewsState.currentView
- * @property {"all-news-tab" | "subscribed-news-tab"} MainNewsState.currentDataType
- * @property {number | null} MainNewsState.currentTabId
- * @property {number} MainNewsState.currentDataIndex
+ * @property {'list-view' | 'grid-view' } MainNewsState.viewTabId
+ * @property {"all-news-tab" | "subscribed-news-tab"} MainNewsState.dataTabId
+ * @property {number | null} MainNewsState.categoryId
+ * @property {number} MainNewsState.companyIndex
  * @property {number} MainNewsState.totalTabNumber
  * @property {Company[]} MainNewsState.companies
  */

--- a/src/types/news.js
+++ b/src/types/news.js
@@ -26,9 +26,9 @@
 
 /**
  * @typedef {Object} MainNewsState
- * @property {'list-view' | 'grid-view'} MainNewsState.currentView
+ * @property {'list-view' | 'grid-view' } MainNewsState.currentView
  * @property {"all-news-tab" | "subscribed-news-tab"} MainNewsState.currentDataType
- * @property {number} MainNewsState.currentTabId
+ * @property {number | null} MainNewsState.currentTabId
  * @property {number} MainNewsState.currentDataIndex
  * @property {number} MainNewsState.totalTabNumber
  * @property {Company[]} MainNewsState.companies

--- a/src/types/news.js
+++ b/src/types/news.js
@@ -29,7 +29,7 @@
  * @property {'list-view' | 'grid-view'} MainNewsState.currentView
  * @property {"all-news-tab" | "subscribed-news-tab"} MainNewsState.currentDataType
  * @property {number} MainNewsState.currentTabId
- * @property {number} MainNewsState.currentCompanyIndex
+ * @property {number} MainNewsState.currentDataIndex
  * @property {number} MainNewsState.totalTabNumber
  * @property {Company[]} MainNewsState.companies
  */

--- a/src/types/news.js
+++ b/src/types/news.js
@@ -31,7 +31,7 @@
  * @property {number} MainNewsState.currentTabId
  * @property {number} MainNewsState.currentCompanyIndex
  * @property {number} MainNewsState.totalTabNumber
- * @property {Company[]} MainNewsState.data
+ * @property {Company[]} MainNewsState.companies
  */
 
 export const NewsCategory = {};


### PR DESCRIPTION
### preview
<img width="1276" alt="스크린샷 2024-07-12 오전 1 36 32" src="https://github.com/nimod7890/fe-newsstand/assets/80194238/9a91c17f-c669-4f26-92eb-f011d9d3b6e8">

<img width="934" alt="스크린샷 2024-07-12 오전 1 42 03" src="https://github.com/nimod7890/fe-newsstand/assets/80194238/4d47dbc8-c1da-4ca8-817e-20ba7c06cbe5">

<img width="486" alt="스크린샷 2024-07-12 오전 1 37 01" src="https://github.com/nimod7890/fe-newsstand/assets/80194238/b42f3b4a-1d3b-4093-b328-ec4d1180d4de">

### 작업사항
1. 한번에 24개 그리드 레이아웃 유지한 상태로 화면 크기에 따라 최대 4*6 크기를 차지하는 그리드 화면 구현
2. 전체 언론사인 경우 기본 그리드 화면으로 보여주기
3. 구독한 언론사인 경우 기본 리스트 화면으로 보여주기
4. 그리드 화면에서 구독 버튼 onclick event는 부모(언론사 컴포넌트)에 반영
5. 리스트/그리드 뷰, 전체언론사/구독한 언론사 데이터 경우의 수마다 구독 / 구독 해제 기능 동작 전부 확인 완료


```js
(isGridView ? container : button).addEventListener("click", () => handleSubscriptionClick(props));
```